### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
+    @items = Item.includes(:user).order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    @items = Item.includes(:user).order("created_at DESC")
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new
@@ -19,6 +19,7 @@ class ItemsController < ApplicationController
   end
 
   private
+
   def item_params
     params.require(:item).permit(:image, :name, :content, :category_id, :condition_id, :delivery_fee_id, :prefecture_id, :period_id, :price).merge(user_id: current_user.id)
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,16 +1,16 @@
 class Category < ActiveHash::Base
   self.data = [
-    { id: 1, name: '---'},
-    { id: 2, name: 'レディース'},
-    { id: 3, name: 'メンズ'},
-    { id: 4, name: 'ベビー・キッズ'},
-    { id: 5, name: 'インテリア・住まい・小物'},
-    { id: 6, name: '本・音楽・ゲーム'},
-    { id: 7, name: 'おもちゃ・ホビー・グッズ'},
-    { id: 8, name: '家電・スマホ・カメラ'},
-    { id: 9, name: 'スポーツ・レジャー'},
-    { id: 10, name: 'ハンドメイド'},
-    { id: 11, name: 'その他'}
+    { id: 1, name: '---' },
+    { id: 2, name: 'レディース' },
+    { id: 3, name: 'メンズ' },
+    { id: 4, name: 'ベビー・キッズ' },
+    { id: 5, name: 'インテリア・住まい・小物' },
+    { id: 6, name: '本・音楽・ゲーム' },
+    { id: 7, name: 'おもちゃ・ホビー・グッズ' },
+    { id: 8, name: '家電・スマホ・カメラ' },
+    { id: 9, name: 'スポーツ・レジャー' },
+    { id: 10, name: 'ハンドメイド' },
+    { id: 11, name: 'その他' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,12 +1,12 @@
 class Condition < ActiveHash::Base
   self.data = [
-    { id: 1, name: '---'},
-    { id: 2, name: '新品、未使用'},
-    { id: 3, name: '未使用に近い'},
-    { id: 4, name: '目立った傷や汚れなし'},
-    { id: 5, name: 'やや傷や汚れあり'},
-    { id: 6, name: '傷や汚れあり'},
-    { id: 7, name: '全体的に状態が悪い'}
+    { id: 1, name: '---' },
+    { id: 2, name: '新品、未使用' },
+    { id: 3, name: '未使用に近い' },
+    { id: 4, name: '目立った傷や汚れなし' },
+    { id: 5, name: 'やや傷や汚れあり' },
+    { id: 6, name: '傷や汚れあり' },
+    { id: 7, name: '全体的に状態が悪い' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/delivery_fee.rb
+++ b/app/models/delivery_fee.rb
@@ -1,8 +1,8 @@
 class DeliveryFee < ActiveHash::Base
   self.data = [
-    { id: 1, name: '---'},
-    { id: 2, name: '着払い(購入者負担)'},
-    { id: 3, name: '送料込み(出品者負担)'}
+    { id: 1, name: '---' },
+    { id: 2, name: '着払い(購入者負担)' },
+    { id: 3, name: '送料込み(出品者負担)' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,7 +3,7 @@ class Item < ApplicationRecord
     validates :image
     validates :name
     validates :content
-    validates :price, format: { with: /\A[0-9]+\z/, message: 'is invalid. Input half-width characters.' }, numericality: {greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999, message: 'Out of setting range'}
+    validates :price, format: { with: /\A[0-9]+\z/, message: 'is invalid. Input half-width characters.' }, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'Out of setting range' }
 
     with_options numericality: { other_than: 1, message: 'Select' } do
       validates :category_id

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -1,9 +1,9 @@
 class Period < ActiveHash::Base
   self.data = [
-    { id: 1, name: '---'},
-    { id: 2, name: '1~2日で発送'},
-    { id: 3, name: '2~3日で発送'},
-    { id: 4, name: '4~7日で発送'},
+    { id: 1, name: '---' },
+    { id: 2, name: '1~2日で発送' },
+    { id: 3, name: '2~3日で発送' },
+    { id: 4, name: '4~7日で発送' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,23 +1,23 @@
 class Prefecture < ActiveHash::Base
   self.data = [
-    {id: 1, name: '---'}, {id: 2, name: '北海道'}, {id: 3, name: '青森県'}, 
-    {id: 4, name: '岩手県'}, {id: 5, name: '宮城県'}, {id: 6, name: '秋田県'}, 
-    {id: 7, name: '山形県'}, {id: 8, name: '福島県'}, {id: 9, name: '茨城県'}, 
-    {id: 10, name: '栃木県'}, {id: 11, name: '群馬県'}, {id: 12, name: '埼玉県'}, 
-    {id: 13, name: '千葉県'}, {id: 14, name: '東京都'}, {id: 15, name: '神奈川県'}, 
-    {id: 16, name: '新潟県'}, {id: 17, name: '富山県'}, {id: 18, name: '石川県'}, 
-    {id: 19, name: '福井県'}, {id: 20, name: '山梨県'}, {id: 21, name: '長野県'}, 
-    {id: 22, name: '岐阜県'}, {id: 23, name: '静岡県'}, {id: 24, name: '愛知県'}, 
-    {id: 25, name: '三重県'}, {id: 26, name: '滋賀県'}, {id: 27, name: '京都府'}, 
-    {id: 28, name: '大阪府'}, {id: 29, name: '兵庫県'}, {id: 30, name: '奈良県'}, 
-    {id: 31, name: '和歌山県'}, {id: 32, name: '鳥取県'}, {id: 33, name: '島根県'}, 
-    {id: 34, name: '岡山県'}, {id: 35, name: '広島県'}, {id: 36, name: '山口県'}, 
-    {id: 37, name: '徳島県'}, {id: 38, name: '香川県'}, {id: 39, name: '愛媛県'}, 
-    {id: 40, name: '高知県'}, {id: 41, name: '福岡県'}, {id: 42, name: '佐賀県'}, 
-    {id: 43, name: '長崎県'}, {id: 44, name: '熊本県'}, {id: 45, name: '大分県'}, 
-    {id: 46, name: '宮崎県'}, {id: 47, name: '鹿児島県'}, {id: 48, name: '沖縄県'}
-   ]
+    { id: 1, name: '---' }, { id: 2, name: '北海道' }, { id: 3, name: '青森県' },
+    { id: 4, name: '岩手県' }, { id: 5, name: '宮城県' }, { id: 6, name: '秋田県' },
+    { id: 7, name: '山形県' }, { id: 8, name: '福島県' }, { id: 9, name: '茨城県' },
+    { id: 10, name: '栃木県' }, { id: 11, name: '群馬県' }, { id: 12, name: '埼玉県' },
+    { id: 13, name: '千葉県' }, { id: 14, name: '東京都' }, { id: 15, name: '神奈川県' },
+    { id: 16, name: '新潟県' }, { id: 17, name: '富山県' }, { id: 18, name: '石川県' },
+    { id: 19, name: '福井県' }, { id: 20, name: '山梨県' }, { id: 21, name: '長野県' },
+    { id: 22, name: '岐阜県' }, { id: 23, name: '静岡県' }, { id: 24, name: '愛知県' },
+    { id: 25, name: '三重県' }, { id: 26, name: '滋賀県' }, { id: 27, name: '京都府' },
+    { id: 28, name: '大阪府' }, { id: 29, name: '兵庫県' }, { id: 30, name: '奈良県' },
+    { id: 31, name: '和歌山県' }, { id: 32, name: '鳥取県' }, { id: 33, name: '島根県' },
+    { id: 34, name: '岡山県' }, { id: 35, name: '広島県' }, { id: 36, name: '山口県' },
+    { id: 37, name: '徳島県' }, { id: 38, name: '香川県' }, { id: 39, name: '愛媛県' },
+    { id: 40, name: '高知県' }, { id: 41, name: '福岡県' }, { id: 42, name: '佐賀県' },
+    { id: 43, name: '長崎県' }, { id: 44, name: '熊本県' }, { id: 45, name: '大分県' },
+    { id: 46, name: '宮崎県' }, { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
+  ]
 
-   include ActiveHash::Associations
-   has_many :items
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,12 +125,13 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
+    <% if @items.present? %>
+      <% @items.each do |item| %>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,10 +142,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.delivery_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -154,8 +155,9 @@
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
+      <% end %>
       <%# 商品がない場合のダミー %>
+    <% else %>
       <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
@@ -175,6 +177,7 @@
         <% end %>
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>
+    <% end %>
       <%# /商品がない場合のダミー %>
     </ul>
   </div>

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :category do
-    
   end
 end

--- a/spec/factories/conditions.rb
+++ b/spec/factories/conditions.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :condition do
-    
   end
 end

--- a/spec/factories/delivery_fees.rb
+++ b/spec/factories/delivery_fees.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :delivery_fee do
-    
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :item do
-    name            {Faker::Commerce.product_name}
-    content         {Faker::Lorem.sentence}
-    category_id     {2}
-    condition_id    {2}
-    delivery_fee_id {2}
-    prefecture_id   {2}
-    period_id       {2}
-    price           {Faker::Commerce.price(range: 300..10000).to_i}
+    name            { Faker::Commerce.product_name }
+    content         { Faker::Lorem.sentence }
+    category_id     { 2 }
+    condition_id    { 2 }
+    delivery_fee_id { 2 }
+    prefecture_id   { 2 }
+    period_id       { 2 }
+    price           { Faker::Commerce.price(range: 300..10_000).to_i }
     association :user
 
     after(:build) do |item|

--- a/spec/factories/periods.rb
+++ b/spec/factories/periods.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :period do
-    
   end
 end

--- a/spec/factories/prefectures.rb
+++ b/spec/factories/prefectures.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :prefecture do
-    
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -31,27 +31,27 @@ RSpec.describe Item, type: :model do
       it 'category_idを選択していないと商品出品に失敗する' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category Select")
+        expect(@item.errors.full_messages).to include('Category Select')
       end
       it 'condition_idを選択していないと商品出品に失敗する' do
         @item.condition_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Condition Select")
+        expect(@item.errors.full_messages).to include('Condition Select')
       end
       it 'delivery_fee_idを選択していないと商品出品に失敗する' do
         @item.delivery_fee_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery fee Select")
+        expect(@item.errors.full_messages).to include('Delivery fee Select')
       end
       it 'prefecture_idを選択していないと商品出品に失敗する' do
         @item.prefecture_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture Select")
+        expect(@item.errors.full_messages).to include('Prefecture Select')
       end
       it 'period_idを選択していないと商品出品に失敗する' do
         @item.period_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Period Select")
+        expect(@item.errors.full_messages).to include('Period Select')
       end
       it 'priceが空だと商品出品に失敗する' do
         @item.price = nil
@@ -61,17 +61,17 @@ RSpec.describe Item, type: :model do
       it 'priceが300未満だと商品出品に失敗する' do
         @item.price = 200
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
       it 'priceが9,999,999より大きいと商品出品に失敗する' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
       it '出品する商品に紐づくユーザーがいないとき商品出品に失敗する' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("User must exist")
+        expect(@item.errors.full_messages).to include('User must exist')
       end
     end
   end


### PR DESCRIPTION
#What
・indexアクションの編集
・index.html.erbの編集

#Why
出品した商品を一覧表示するため

・未ログインでの一覧画面の様子↓
https://gyazo.com/08afa48376901a1ae521e83cc30f735d

・ログイン時での一覧画面の様子↓
https://gyazo.com/6afa3dc9d9cf7aa5cba9bf9e8a9e8611

・itemsテーブル↓
https://gyazo.com/4cc716af63f88e65071fcb0c02e6af20

※削除機能の実装がこれからで、出品商品がないときの一覧画面が実際どうなるかまだわからず、その時に参考にする可能性があるので、index.html.erbのコメントアウトは現段階では残すことにしました。